### PR TITLE
Update to match feedback from code review

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,134 @@
+# Project 2
+
+
+This project uses the `lexer` and `parser` functions from Project 1 and Project 2 to get an instance of a `DatalogProgram` that must then be interpreted to answer its queries. Project 3 must
+
+  1. Create a relation for each named scheme in the Datalog program.
+  1. Add each fact in the Datalog program to the appropriate relation.
+  1. Evaluate each query in the Datalog program and return the answers to each one.
+
+**There is no rule evaluation for project 3.** Anything related to evaluating rules, including the natural join of two relations, is **not a part of project 3.**
+
+The interpreter **must be implemented with relational algebra.** No exceptions. And the queries must be evaluated using relational algebra. Specifically, project, rename, and select along with union, intersection, and difference as appropriate.
+
+**Before proceeding further, please review the Project 3 project description, lecture slides, and all of the associated Jupyter notebooks. You can thank us later for the suggestion.**
+
+## Developer Setup
+
+Be sure to read the [WARNING](#warning) and [Copy Files](#copy-files) sections.
+
+As in Project 2, the first step is to clone the repository created by GitHub Classroom when the assignment was accepted in a sensible directory. In the vscode terminal, `git clone <URL>` where `<URL>` is the one from GitHub Classroom after accepting the assignment. Or open a new vscode window, select _Clone Git Repository_, and paste the link they get when they hover over the "<> Code ▼" and copy the url
+
+There is no need to install any vscode extensions. These should all still be present and active from the previous project. You do need to create the virtual environment, install the package, and install pre-commit. For a reminder to how that is done, see on [learningsuite.byu.edu](https://learningsuite.byu.edu) _Content_ &rarr; _Projects_ &rarr; _Projects Cheat Sheet_
+
+  * Create a virtual environment: **be sure to create it in the `project-3` folder.** `python -m venv .venv`
+  * Activate the virtual environment: `source .venv/bin/activate` or `.venv\Scripts\activate` for OSX and windows respectively.
+  * Install the package in edit mode: `pip install --editable ".[dev]"`
+  * Install pre-commit: `pre-commit install`
+
+The above should result in a `project3` executable that is run from the command line in an integrated terminal. As before, be sure the integrated terminal is in the virtual environment.
+
+### WARNING
+
+  * Be sure that the `conda` environment is not active when setting up the project. It's active when there is a `(base)` annotation next to the terminal prompt. The `conda deactivate` command will exit that environment.
+  * Be sure the Python version is at least 3.11 -- `python --version`.
+  * Open the project folder in vscode when working on the project, and not a folder above it or below it, otherwise the paths for the pass-off tests will not work -- the common error is _"no project3 module found"_.
+  * Be sure that vscode is using the virtual environment in the project folder: choose `Python Select Interpreter` from the command pallette and select the Python in the `.venv` folder -- its usually the first option if vscode opened that folder as the workspace.
+
+## Files
+
+  * `.devcontainer`: container definition for those using docker with vscode
+  * `.github`: workflow definitions
+  * `README.md`: overview and directions
+  * `config_test.sh`: support for auto-grading -- **please do not edit**
+  * `pyproject.toml`: package definition and project configuration -- **please do not edit**
+  * `pytest.ini`: custom pytest marks for pass-off -- **please do not edit**
+  * `src`: folder for the package source files
+  * `tests`: folder for the package test files
+  * `.gitignore`: files patterns that git should ignore
+
+### Copy Files
+
+Copy the below files from your solution to Project 2 into the `src/project2/` folder:
+
+  * `datalogprogram.py`
+  * `fsm.py`
+  * `lexer.py`
+  * `parser.py`
+
+The `token.py` file is unchanged here and should not be copied over. None of test files from Project 1 should be copied over either.
+
+### Reminder
+
+Please do not edit any of the following files or directories as they are related to _auto-grading_ and _pass-off_:
+
+  * `config_test.sh`
+  * `pytest.ini`
+  * `./tests/test_passoff.py`
+  * `./tests/resources/project3-passoff/*`
+
+## Overview
+
+The project is divided into the following modules each representing a key component of the project:
+
+  * `src/project3/interpreter.py`: defines the `Interpreter` class with its interface.
+  * `src/project3/project3.py`: defines the entry point for auto-grading and the command line entry point.
+  * `src/project3/relation.py`: defines the `Relation` class with its interface.
+  * `src/project3/reporter.py`: defines functions for reporting the results of the interpreter.
+
+Each of the above files are specified with Python _docstrings_ and they also have examples defined with python _doctests_. A _docstring_ is a way to document Python code so that the command `help(project3.relation)` in the Python interpreter outputs information about the module with it's functions and classes. For functions, the docstrings give documentation when the mouse hovers over the function in vscode.
+
+### interpreter.py
+
+A portion of the `Interpreter` class needs to be implemented for project 3: `eval_schemes`, `eval_facts`, and `eval_queries`. The docstrings describe what
+each should do. Relation algebra must be used for `eval_queries`. There are no provided tests. You are expected to write tests for each function before starting any implementation. Be sure to add to the repository the file with the tests.
+
+### project3.py
+
+The entry point for the auto-grader and the `project3` command. See the docstrings for details.
+
+### relation.py
+
+Some of the `Relation` class is already implemented. The attributes are complete as is the interface. A portion of the `Relation` class needs to be implemented for project 3: `intersection` (easy), `project` (hard), `rename` (super easy), `select_eq_col` (moderate), `select_eq_lit` (moderate), and `union` (easy). **You do not need natural join for project 3**.
+
+The docstrings describe what each function should do. There are tests in `./tests/test_relation.py` for the provided portions of the class that are implemented already. You are expected to write negative and positive tests for each function before starting any implementation. A negative test is one where an error is expected (e.g., bad operands to an operation). Follow the examples provided in the test file.
+
+### reporter.py
+
+A module for output matching in the pass-off tests. It takes the interface defined by `Interpreter` and converts the return types to strings that are used for the actual query reports that must output match for pass-off. _This module should work out of the box and not need to be touched_.
+
+## Where to start
+
+Here is the suggested order for Project 3:
+
+1. Read the code and order in your mind what has been provided, how it works, and what you need to implement -- **don't skip this step**.
+1. For each required function in `Relation`:
+
+    1. Write a negative test that fails.
+    1. Write code to pass the negative test.
+    1. Write a positive test that fails.
+    1. Write code to pass the positive test.
+
+1. For each required function in `Interpreter`:
+
+    1. Write a positive test that fails.
+    1. Write code to pass the positive test.
+
+1. Run the pass-off tests -- debug as needed.
+
+## Pass-off and Submission
+
+**The pass-off test structure has changed.** All the tests are in a single file: `tests/test-passoff.py`. These use custom marks defined in `pytest.ini` to group the tests into buckets. They also now use parameterization to avoid code duplication. Running individual tests is the same using either `pytest` directly or the testing pane in vscode (**recommended**).
+
+The minimum standard for this project is **bucket 80**. That means that if all the tests pass in all buckets up to and including bucket 80, then the next project can be started safely.
+
+The Project 3 submission follows that of the other projects:
+
+  * Commit your solution on the master branch -- be sure to add any new files!
+  * Push the commit to GitHub -- that should trigger the auto-grader
+  * Goto [learningsuite.byu.edu](https://learningsuite.byu.edu) at _Assignments_ &rarr; _Projects_ &rarr; _Project 2_ to submit your GitHub ID and Project 2 URL for grading.
+  * Goto the Project 3 URL, find the green checkmark or red x, and click it to confirm the auto-grader score matches the pass-off results from your system.
+
+### Branches
+
+Consider using a branch as you work on your submission so that you can `commit` your work from time to time. Once everything is working, and the auto-grader tests are passing, then you can `merge` your work into your master branch and push it to your GitHub repository. Ask your favorite search engine or LLM for help learning how to use Git feature branches.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ version = "0.0.1"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-  "sortedcontainers",
   "tabulate",
 ]
 

--- a/src/project3/interpreter.py
+++ b/src/project3/interpreter.py
@@ -1,3 +1,9 @@
+"""Interpreter for Datalog programs.
+
+Provides an interpreter interface for interpreting Datalog
+programs using relational algebra.
+"""
+
 from typing import Iterator
 
 from project3.datalogprogram import DatalogProgram, Predicate, Rule
@@ -5,15 +11,38 @@ from project3.relation import Relation
 
 
 class Interpreter:
+    """Interpreter class for Datalog.
+
+    Defines the interface, and a place for the implementation, for interpreting
+    Datalog programs. The interpreter must be implemented using relational algebra,
+    so new attributes must be added to track the named relations in the Datalog
+    program during the lifetime of the interpreter.
+
+    Attributes:
+        datalog (DatalogProgram): The Datalog program to interpret.
+    """
+
     __slots__ = ["datalog"]
 
     def __init__(self, datalog: DatalogProgram) -> None:
         self.datalog = datalog
 
     def eval_schemes(self) -> None:
+        """Evaluate the schemes in the Datalog program.
+
+        Create, and store in the interpreter, a relation for each scheme
+        in the Datalog program. The _name_ of the scheme must be stored
+        separate from the relation since the `Relation` type has no name
+        attribute.
+        """
         raise NotImplementedError
 
     def eval_facts(self) -> None:
+        """Evaluate the facts in the Datalog program.
+
+        Create, and store in the appropriate relation belonging to the
+        interpreter, a tuple for each fact in the Datalog program.
+        """
         raise NotImplementedError
 
     def eval_queries(self) -> Iterator[tuple[Predicate, Relation]]:
@@ -21,21 +50,24 @@ class Interpreter:
 
         For each query in the Datalog program, evaluate the query to get a
         resulting relation that is the answer to the query, and then yield
-        the resulting (query, relation) pair.
+        the resulting `(query, relation)` tuple.
 
         Returns:
-            out: An iterator to a tuple where the first element is the predicate
-                for the query and the second element is the relation for the answer.
+            out (tuple[Predicate, Relation]): An iterator to a tuple where the
+            first element is the predicate for the query and the second element
+            is the relation for the answer.
         """
         raise NotImplementedError
 
     def eval_rules(self) -> Iterator[tuple[Relation, Rule, Relation]]:
-        """Yield each before relation, rule, and after relation from evaluation.
+        """Yield each _before_ relation, rule, and _after_ relation from evaluation.
 
-        For each rule in the Datalog program, yield the relation associated with
-        the rule before evaluating the rule one time, the rule itself, and then
+        For each rule in the Datalog program, yield as a tuple the relation associated
+        with the rule before evaluating the rule one time, the rule itself, and then
         the resulting relation after evaluating the rule one time. This process
         should repeat until the associated relations stop changing.
+        All the generated facts should be stored in the appropriate relation
+        in the interpreter.
 
         For example, given `rule_a` for relation `A`, `rule_b` for
         relation `B`, and that it takes three evaluations to see no change, then
@@ -53,14 +85,15 @@ class Interpreter:
         `B_2 == B_3`.
 
         Returns:
-            out: An iterator to a tuple where the first element is the relation before rule
-                evaluation, the second element is the rule associated with the relation, and
-                the third element is the relation resulting from the rule evaluation.
+            out (Iterator[tuple[Relation, Rule, Relation]]): An iterator to a tuple where the
+                first element is the relation before rule evaluation, the second element is
+                the rule associated with the relation, and the third element is the relation
+                resulting from the rule evaluation.
         """
         raise NotImplementedError
 
     def eval_rules_optimized(self) -> Iterator[tuple[Relation, Rule, Relation]]:
-        """Yield each before relation, rule, and after relation from optimized evaluation.
+        """Yield each _before_ relation, rule, and _after_ relation from optimized evaluation.
 
         This function is the same as the `eval_rules` function only it groups rules by strongly
         connected components (SCC) in the dependency graph from the rules in the Datalog
@@ -84,9 +117,10 @@ class Interpreter:
         and stops after two iterations when `C_1 == C_2`.
 
         Returns:
-            out: An iterator to a tuple where the first element is the relation before rule
-                evaluation, the second element is the rule associated with the relation, and
-                the third element is the relation resulting from the rule evaluation.
+            out (Iterator[tuple[Relation, Rule, Relation]]): An iterator to a tuple where the
+                first element is the relation before rule evaluation, the second element is the
+                rule associated with the relation, and the third element is the relation resulting
+                from the rule evaluation.
         """
         raise NotImplementedError
 

--- a/src/project3/interpreter.py
+++ b/src/project3/interpreter.py
@@ -1,7 +1,7 @@
 from typing import Iterator
 
-from project3.datalogprogram import DatalogProgram
-from project3.reporter import QueryReporter, RuleReporter, RuleOptimizedReporter
+from project3.datalogprogram import DatalogProgram, Predicate, Rule
+from project3.relation import Relation
 
 
 class Interpreter:
@@ -16,11 +16,92 @@ class Interpreter:
     def eval_facts(self) -> None:
         raise NotImplementedError
 
-    def eval_queries(self) -> Iterator[QueryReporter]:
+    def eval_queries(self) -> Iterator[tuple[Predicate, Relation]]:
+        """Yield each query and resulting relation from evaluation."
+
+        For each query in the Datalog program, evaluate the query to get a
+        resulting relation that is the answer to the query, and then yield
+        the resulting (query, relation) pair.
+
+        Returns:
+            out: An iterator to a tuple where the first element is the predicate
+                for the query and the second element is the relation for the answer.
+        """
         raise NotImplementedError
 
-    def eval_rules(self) -> Iterator[RuleReporter]:
+    def eval_rules(self) -> Iterator[tuple[Relation, Rule, Relation]]:
+        """Yield each before relation, rule, and after relation from evaluation.
+
+        For each rule in the Datalog program, yield the relation associated with
+        the rule before evaluating the rule one time, the rule itself, and then
+        the resulting relation after evaluating the rule one time. This process
+        should repeat until the associated relations stop changing.
+
+        For example, given `rule_a` for relation `A`, `rule_b` for
+        relation `B`, and that it takes three evaluations to see no change, then
+        `eval_rules` should:
+
+            yield((A_0, rule_a, A_1))
+            yield((B_0, rule_b, B_1))
+            yield((A_1, rule_a, A_2))
+            yield((B_1, rule_b, B_2))
+            yield((A_2, rule_a, A_3))
+            yield((B_2, rule_b, B_3))
+
+        Here `A_0` is the initial relation for `A`, `A_1` is the relation after evaluating
+        `rule_a` on `A_0` etc. The same for `B`. The iteration stops because `A_2 == A_3` and
+        `B_2 == B_3`.
+
+        Returns:
+            out: An iterator to a tuple where the first element is the relation before rule
+                evaluation, the second element is the rule associated with the relation, and
+                the third element is the relation resulting from the rule evaluation.
+        """
         raise NotImplementedError
 
-    def eval_rules_optimized(self) -> Iterator[RuleOptimizedReporter]:
+    def eval_rules_optimized(self) -> Iterator[tuple[Relation, Rule, Relation]]:
+        """Yield each before relation, rule, and after relation from optimized evaluation.
+
+        This function is the same as the `eval_rules` function only it groups rules by strongly
+        connected components (SCC) in the dependency graph from the rules in the Datalog
+        program. So given the first SCC is with `rule_a` for relation `A`, `rule_b` for
+        relation `B`, that takes three evaluations to see no change, and the second SCC with
+        `rule_c for relation C that takes two evaluations to see no change, then
+        `eval_rules_opt` should:
+
+            yield((A_0, rule_a, A_1))
+            yield((B_0, rule_b, B_1))
+            yield((A_1, rule_a, A_2))
+            yield((B_1, rule_b, B_2))
+            yield((A_2, rule_a, A_3))
+            yield((B_2, rule_b, B_3))
+            yield((C_0, rule_c, C_1))
+            yield((C_1, rule_c, C_2))
+
+        Here `A_0` is the initial relation for `A`, `A_1` is the relation after evaluating
+        `rule_a` on `A_0` etc. The same for `B` and `C`. The iteration on the first SCC stops
+        because `A_2 == A_3` and `B_2 == B_3`. After the iteration for the second SCC starts
+        and stops after two iterations when `C_1 == C_2`.
+
+        Returns:
+            out: An iterator to a tuple where the first element is the relation before rule
+                evaluation, the second element is the rule associated with the relation, and
+                the third element is the relation resulting from the rule evaluation.
+        """
+        raise NotImplementedError
+
+    def get_rule_dependency_graph(self) -> dict[str, list[str]]:
+        """Return the rule dependency graph.
+
+        Computes and returns the graph formed by dependencies between rules.
+        The graph is used to compute strongly connected components of rules
+        for optimized rule evaluation.
+
+        Rules are zero-indexed so the first rule in the Datalog program is `R0`,
+        the second rules is `R1`, etc. A return of `{R0 : [R0, R1], R1 : [R2]}`
+        means that `R0` has edges to `R0` and `R1`, and `R1` has an edge to `R2`.
+
+        Returns:
+            out: A map with an entry for each rule and the associated rules connected to it.
+        """
         raise NotImplementedError

--- a/src/project3/project3.py
+++ b/src/project3/project3.py
@@ -1,3 +1,5 @@
+"""Project 3 query interpreter for Datalog programs."""
+
 from sys import argv
 from typing import Iterator
 
@@ -10,6 +12,17 @@ from project3.token import Token
 
 
 def project3(input_string: str) -> str:
+    """Interpret queries in the Datalog program input.
+
+    The function creates the lexer and parser to turn the input string into
+    a `DatalogProgram` instance. It then uses the interpreter to get the
+    answers to each query in the Datalog program. The answers are formatted for output
+    matching with an appropriate reporter interface.
+
+    Returns:
+        answer (str): The string representing the answers for each query in the
+        given Datalog program or a parse failure.
+    """
     token_iterator: Iterator[Token] = lexer(input_string)
     try:
         datalog_program: DatalogProgram = parse(token_iterator)
@@ -26,7 +39,7 @@ def project3cli() -> None:
     """Answer queries in a Datalog program
 
     `project3cli` is only called from the command line in the integrated terminal.
-    Prints the results of each query in the Datalog program to the terminal.
+    This function prints the results of each query in the Datalog program to the terminal.
 
     Args:
         argv (list[str]): Generated from the command line and needs to name the input file.

--- a/src/project3/project3.py
+++ b/src/project3/project3.py
@@ -5,6 +5,7 @@ from project3.interpreter import Interpreter
 from project3.datalogprogram import DatalogProgram
 from project3.lexer import lexer
 from project3.parser import parse, UnexpectedTokenException
+from project3.reporter import query_report
 from project3.token import Token
 
 
@@ -15,8 +16,8 @@ def project3(input_string: str) -> str:
         interpreter: Interpreter = Interpreter(datalog_program)
         interpreter.eval_schemes()
         interpreter.eval_facts()
-        answer = [str(i) for i in interpreter.eval_queries()]
-        return "\n".join(answer)
+        answer = "\n".join([query_report(i, j) for i, j in interpreter.eval_queries()])
+        return answer
     except UnexpectedTokenException as e:
         return "Failure!\n  " + str(e.token)
 

--- a/src/project3/relation.py
+++ b/src/project3/relation.py
@@ -1,26 +1,49 @@
-from tabulate import tabulate
+"""Relation type for interpreting Datalog."""
 
+from tabulate import tabulate
 from typing import Any
 
 
 class IncompatibleOperandError(Exception):
+    """Type for relational algebra operand errors."""
+
     def __init__(self, msg: str) -> None:
         super().__init__(msg)
 
 
-class Relation:
-    __slots__ = ["header", "set_of_tuples"]
+RelationTuple = tuple[str, ...]
+"""Defines a type for tuples in the relation. Here the tuple can be any number of strings."""
 
-    RelationTuple = tuple[str, ...]
+
+class Relation:
+    """Relation class for relational algebra.
+
+    The interface for the class is complete meaning that it defines all the
+    needed attributes and relation operations to implement the Datalog interpreter.
+    It is expected that additional internal functions are to be added in support
+    of the published public interface. No additional attributes should be needed.
+
+    Attributes:
+        header (list[str]): The relation header.
+        set_of_tuples (set[RelationTuple]): The tuples belonging to the relation.
+    """
+
+    __slots__ = ["header", "set_of_tuples"]
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, Relation):
             return False
         return self.header == other.header and self.set_of_tuples == other.set_of_tuples
 
-    def __init__(self, header: list[str], set_of_tuples: set[RelationTuple]):
+    def __init__(self, header: list[str], set_of_tuples: set[RelationTuple]) -> None:
+        """Initialize a new relation.
+
+        The `RelationTuple` type is not mutable, so it is not necessary to make
+        new copies when initializing a new relation. The list for the header and
+        the set of tuples are mutable, so here new instances are created.
+        """
         self.header = list(header)
-        self.set_of_tuples: set[Relation.RelationTuple] = set()
+        self.set_of_tuples: set[RelationTuple] = set()
         for i in set_of_tuples:
             self.add_tuple(i)
 
@@ -28,11 +51,27 @@ class Relation:
         return f"Relation(header={self.header!r}, set_of_tuples={self.set_of_tuples!r})"
 
     def __str__(self) -> str:
+        """Return the relation as a string.
+
+        A `set` type in Python is not sorted, and indeed, the order of elements
+        in the set though defined by the hash of each tuple is non-deterministic
+        from machine to machine and run to run. Here the tuples in the set are
+        sorted so that the string representation is always deterministic.
+
+        Returns:
+            value (str): The relation as a string.
+        """
         sorted_tuples = sorted(self.set_of_tuples)
         value: str = tabulate(iter(sorted_tuples), self.header, tablefmt="pretty")
         return value
 
     def add_tuple(self, r: RelationTuple) -> None:
+        """Add a new tuple to the relation.
+
+        Raises:
+            error (IncompatibleOperandError): Error if the length of the tuple doesn't
+                match the header or if the thing being added isn't a tuple of strings.
+        """
         if len(self.header) != len(r):
             raise IncompatibleOperandError(
                 f"Error: {r} is not compatible with header {self.header} in Relation.add_tuple"
@@ -44,6 +83,16 @@ class Relation:
         self.set_of_tuples.add(r)
 
     def difference(self, right_operand: "Relation") -> "Relation":
+        """The difference between this relation and another.
+
+        The left operand is this relation (self) and the right operand
+        is provided in the function call. The headers must be the same.
+
+        Returns:
+            r (Relation): A new relation that is self - right_operand.
+        Raises:
+            error (IncompatibleOperandError): Error if the headers are not the same.
+        """
         if self.header != right_operand.header:
             raise IncompatibleOperandError(
                 f"Error: headers {self.header} and {right_operand.header} are not compatible in Relation.difference"
@@ -55,22 +104,98 @@ class Relation:
         return r
 
     def intersection(self, right_operand: "Relation") -> "Relation":
+        """The intersection between this relation and another.
+
+        The left operand is this relation (self) and the right operand
+        is provided in the function call. The headers must agree.
+
+        Returns:
+            r (Relation): A new relation that is self intersect with right_operand.
+        Raises:
+            error (IncompatibleOperandError): Error if the headers are not the same.
+        """
         raise NotImplementedError
 
     def join(self, right_operand: "Relation") -> "Relation":
+        """The natural join between this relation and another.
+
+        The left operand is this relation (self) and the right operand
+        is provided in the function call.
+
+        Returns:
+            r (Relation): A new relation that is self natural join with right_operand.
+        """
         raise NotImplementedError
 
-    def project(self, to: RelationTuple) -> "Relation":
+    def project(self, to: list[str]) -> "Relation":
+        """The projection of this relation to a new header.
+
+        The names in `to` must refer to existing names in the header. The final relation must only
+        include entries in each tuple belonging to those named in `to` and must appear in each tuple
+        in the order they appear in `to`. The final header should match `to` in the new relation.
+
+        Returns:
+            r (Relation): A new relation that is this relation projected to `to`.
+        Raises:
+            error (IncompatibleOperandError): Error if `to` names something not in this relation's header.
+        """
         raise NotImplementedError
 
-    def rename(self, to: RelationTuple) -> "Relation":
+    def rename(self, to: list[str]) -> "Relation":
+        """The rename of this relation to a new header.
+
+        The length of `to` must match the current header. The new resulting relation
+        should match this current relation with the exception of the new header. The
+        header in the new relation should be `to`.
+
+        Returns:
+            r (Relation): A new relation that is this relation renamed to `to`.
+        Raises:
+            error (IncompatibleOperandError): Error if the length of `to` doesn't
+            match the length of the header in this relation.
+        """
         raise NotImplementedError
 
     def select_eq_col(self, src: str, col: str) -> "Relation":
+        """The select of this relation where the `src` entry equals the `col` entry.
+
+        The `src` and `col` must be known in the header. The new resulting relation
+        should only include tuples where the value for `src` is equal to the value
+        for `col`. The header in the new relation is the same as in this relation.
+
+        Returns:
+            r (Relation): A new relation with tuples from this relation that agree
+                on values for `src` and `col`.
+        Raises:
+            error (IncompatibleOperandError): Error if `src` or
+            `col` are not found in the header.
+        """
         raise NotImplementedError
 
     def select_eq_lit(self, src: str, lit: str) -> "Relation":
+        """The select of this relation where the `src` entry equals `lit`.
+
+        The `src` must be known in the header. The new resulting relation
+        should only include tuples where the value for `src` is equal to `lit`.
+        The header in the new relation is the same as in this relation.
+
+        Returns:
+            r (Relation): A new relation with tuples from this relation where the
+                values for `src` is `lit`.
+        Raises:
+            error (IncompatibleOperandError): Error if `src` is not found in the header.
+        """
         raise NotImplementedError
 
     def union(self, right_operand: "Relation") -> "Relation":
+        """The union of this relation and another.
+
+        The left operand is this relation (self) and the right operand
+        is provided in the function call. The headers must agree.
+
+        Returns:
+            r (Relation): A new relation that is self union with right_operand.
+        Raises:
+            error (IncompatibleOperandError): Error if the headers are not the same.
+        """
         raise NotImplementedError

--- a/src/project3/relation.py
+++ b/src/project3/relation.py
@@ -9,30 +9,23 @@ class IncompatibleOperandError(Exception):
 
 
 class Relation:
-    __slots__ = ["name", "header", "set_of_tuples"]
+    __slots__ = ["header", "set_of_tuples"]
 
     RelationTuple = tuple[str, ...]
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, Relation):
             return False
-        return (
-            self.name == other.name
-            and self.header == other.header
-            and self.set_of_tuples == other.set_of_tuples
-        )
+        return self.header == other.header and self.set_of_tuples == other.set_of_tuples
 
-    def __init__(
-        self, name: str, header: RelationTuple, set_of_tuples: set[RelationTuple]
-    ):
-        self.name = name
-        self.header = header
+    def __init__(self, header: list[str], set_of_tuples: set[RelationTuple]):
+        self.header = list(header)
         self.set_of_tuples: set[Relation.RelationTuple] = set()
         for i in set_of_tuples:
             self.add_tuple(i)
 
     def __repr__(self) -> str:
-        return f"Relation(name={self.name!r}, header={self.header!r}, set_of_tuples={self.set_of_tuples!r})"
+        return f"Relation(header={self.header!r}, set_of_tuples={self.set_of_tuples!r})"
 
     def __str__(self) -> str:
         sorted_tuples = sorted(self.set_of_tuples)
@@ -44,6 +37,10 @@ class Relation:
             raise IncompatibleOperandError(
                 f"Error: {r} is not compatible with header {self.header} in Relation.add_tuple"
             )
+        if not isinstance(r, tuple) or any(not isinstance(i, str) for i in r):
+            raise IncompatibleOperandError(
+                f"Error: {r} is not type compatible with Relation.RelationTuple in Relation.add_tuple"
+            )
         self.set_of_tuples.add(r)
 
     def difference(self, right_operand: "Relation") -> "Relation":
@@ -52,7 +49,6 @@ class Relation:
                 f"Error: headers {self.header} and {right_operand.header} are not compatible in Relation.difference"
             )
         r = Relation(
-            self.name,
             self.header,
             self.set_of_tuples.difference(right_operand.set_of_tuples),
         )

--- a/src/project3/relation.py
+++ b/src/project3/relation.py
@@ -1,4 +1,3 @@
-from sortedcontainers import SortedSet  # type: ignore
 from tabulate import tabulate
 
 from typing import Any
@@ -10,9 +9,9 @@ class IncompatibleOperandError(Exception):
 
 
 class Relation:
-    __slots__ = ["name", "header", "rtuples"]
+    __slots__ = ["name", "header", "set_of_tuples"]
 
-    rtuple = tuple[str, ...]
+    RelationTuple = tuple[str, ...]
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, Relation):
@@ -20,29 +19,32 @@ class Relation:
         return (
             self.name == other.name
             and self.header == other.header
-            and self.rtuples == other.rtuples
+            and self.set_of_tuples == other.set_of_tuples
         )
 
-    def __init__(self, name: str, header: rtuple, rtuples: SortedSet[rtuple]):
+    def __init__(
+        self, name: str, header: RelationTuple, set_of_tuples: set[RelationTuple]
+    ):
         self.name = name
         self.header = header
-        self.rtuples = SortedSet()
-        for i in rtuples:
-            self.add_rtuple(i)
+        self.set_of_tuples: set[Relation.RelationTuple] = set()
+        for i in set_of_tuples:
+            self.add_tuple(i)
 
     def __repr__(self) -> str:
-        return f"Relation(name={self.name!r}, header={self.header!r}, rtuples={self.rtuples!r})"
+        return f"Relation(name={self.name!r}, header={self.header!r}, set_of_tuples={self.set_of_tuples!r})"
 
     def __str__(self) -> str:
-        value: str = tabulate(iter(self.rtuples), self.header, tablefmt="pretty")
+        sorted_tuples = sorted(self.set_of_tuples)
+        value: str = tabulate(iter(sorted_tuples), self.header, tablefmt="pretty")
         return value
 
-    def add_rtuple(self, r: rtuple) -> None:
+    def add_tuple(self, r: RelationTuple) -> None:
         if len(self.header) != len(r):
             raise IncompatibleOperandError(
-                f"Error: {r} is not compatible with header {self.header} in Relation.add_rtuple"
+                f"Error: {r} is not compatible with header {self.header} in Relation.add_tuple"
             )
-        self.rtuples.add(r)
+        self.set_of_tuples.add(r)
 
     def difference(self, right_operand: "Relation") -> "Relation":
         if self.header != right_operand.header:
@@ -50,7 +52,9 @@ class Relation:
                 f"Error: headers {self.header} and {right_operand.header} are not compatible in Relation.difference"
             )
         r = Relation(
-            self.name, self.header, self.rtuples.difference(right_operand.rtuples)
+            self.name,
+            self.header,
+            self.set_of_tuples.difference(right_operand.set_of_tuples),
         )
         return r
 
@@ -60,10 +64,10 @@ class Relation:
     def join(self, right_operand: "Relation") -> "Relation":
         raise NotImplementedError
 
-    def project(self, to: rtuple) -> "Relation":
+    def project(self, to: RelationTuple) -> "Relation":
         raise NotImplementedError
 
-    def rename(self, to: rtuple) -> "Relation":
+    def rename(self, to: RelationTuple) -> "Relation":
         raise NotImplementedError
 
     def select_eq_col(self, src: str, col: str) -> "Relation":

--- a/src/project3/reporter.py
+++ b/src/project3/reporter.py
@@ -1,10 +1,13 @@
+"""Functions for output matching in pass-off tests."""
+
 from functools import reduce
 
 from project3.datalogprogram import Predicate
-from project3.relation import Relation
+from project3.relation import Relation, RelationTuple
 
 
 def _is_only_strings(predicate: Predicate) -> bool:
+    """True iff every parameter in the predicate is of type string."""
     return reduce(
         lambda is_only_string, parameter: is_only_string and parameter.is_string(),
         predicate.parameters,
@@ -12,14 +15,26 @@ def _is_only_strings(predicate: Predicate) -> bool:
     )
 
 
-def _tuple_to_str(header: Relation.RelationTuple, r: Relation.RelationTuple) -> str:
+def _tuple_to_str(header: list[str], r: RelationTuple) -> str:
+    """The string representation of a tuple given its associated header."""
     assert len(header) == len(r)
     entries = [f"{i[0]}={i[1]}" for i in zip(header, r)]
     return ", ".join(entries)
 
 
 def query_report(query: Predicate, answer: Relation) -> str:
-    tuples: list[Relation.RelationTuple] = sorted(answer.set_of_tuples)
+    """The string representation of a query report.
+
+    Here the format is the query followed by yes/no with how
+    many tuples match the query. The printing of the tuples
+    includes the header information as in the below.
+
+    SK(A,B)? Yes(3)
+      A='a', B='b'
+      A='a', B='c'
+      A='b', B='c'
+    """
+    tuples: list[RelationTuple] = sorted(answer.set_of_tuples)
     if len(tuples) == 0:
         return f"{query}? No"
 

--- a/src/project3/reporter.py
+++ b/src/project3/reporter.py
@@ -12,39 +12,20 @@ def _is_only_strings(predicate: Predicate) -> bool:
     )
 
 
-def _rtuple_to_str(header: Relation.rtuple, r: Relation.rtuple) -> str:
+def _tuple_to_str(header: Relation.RelationTuple, r: Relation.RelationTuple) -> str:
     assert len(header) == len(r)
     entries = [f"{i[0]}={i[1]}" for i in zip(header, r)]
     return ", ".join(entries)
 
 
-class QueryReporter:
-    __slots__ = ["query", "answer"]
+def query_report(query: Predicate, answer: Relation) -> str:
+    tuples: list[Relation.RelationTuple] = sorted(answer.set_of_tuples)
+    if len(tuples) == 0:
+        return f"{query}? No"
 
-    def __init__(self, query: Predicate, answer: Relation) -> None:
-        self.query = query
-        self.answer = answer
+    if _is_only_strings(query):
+        return f"{query}? Yes({len(tuples)})"
 
-    def __repr__(self) -> str:
-        return f"QueryReporter(query={self.query!r}, answer={self.answer!r})"
-
-    def __str__(self) -> str:
-        if len(self.answer.rtuples) == 0:
-            return f"{self.query}? No"
-
-        if _is_only_strings(self.query):
-            return f"{self.query}? Yes({len(self.answer.rtuples)})"
-
-        entries = [
-            _rtuple_to_str(self.answer.header, row) for row in self.answer.rtuples
-        ]
-        entries_str = "\n  ".join(entries)
-        return f"{self.query}? Yes({len(self.answer.rtuples)})\n  {entries_str}"
-
-
-class RuleReporter:
-    pass
-
-
-class RuleOptimizedReporter:
-    pass
+    entries = [_tuple_to_str(answer.header, row) for row in tuples]
+    entries_str = "\n  ".join(entries)
+    return f"{query}? Yes({len(tuples)})\n  {entries_str}"

--- a/tests/test_relation.py
+++ b/tests/test_relation.py
@@ -1,46 +1,29 @@
 # type: ignore
 import pytest
-from sortedcontainers import SortedSet
 from project3.relation import IncompatibleOperandError, Relation
 
 
-def test_given_empty_relation_when_add_rtuple_then_tuple_in_relation():
+def test_given_empty_relation_when_add_tuple_then_tuple_in_relation():
     # given
     name = "f"
     header = ("a", "b", "c")
-    relation = Relation(name, header, SortedSet())
+    relation = Relation(name, header, set())
     input = ("'1'", "'2'", "'3'")
 
     # when
-    relation.add_rtuple(input)
+    relation.add_tuple(input)
 
     # then
-    assert 1 == len(relation.rtuples)
-    assert input in relation.rtuples
-
-
-def test_given_relation_when_repr_then_match_expected():
-    # given
-    name = "f"
-    header = ("a", "b", "c")
-    rtuples = SortedSet([("'1'", "'2'", "'3'"), ("'1'", "'3'", "'5'")])
-    relation = Relation(name, header, rtuples)
-
-    expected = """Relation(name='f', header=('a', 'b', 'c'), rtuples=SortedSet([("'1'", "'2'", "'3'"), ("'1'", "'3'", "'5'")]))"""
-
-    # when
-    answer = repr(relation)
-
-    # then
-    assert expected == answer
+    assert 1 == len(relation.set_of_tuples)
+    assert input in relation.set_of_tuples
 
 
 def test_given_relation_when_str_then_match_expected():
     # given
     name = "f"
     header = ("a", "b", "c")
-    rtuples = SortedSet([("'1'", "'2'", "'3'"), ("'1'", "'3'", "'5'")])
-    relation = Relation(name, header, rtuples)
+    set_of_tuples = set([("'1'", "'2'", "'3'"), ("'1'", "'3'", "'5'")])
+    relation = Relation(name, header, set_of_tuples)
 
     expected = """+-----+-----+-----+
 |  a  |  b  |  c  |
@@ -56,52 +39,52 @@ def test_given_relation_when_str_then_match_expected():
     assert expected == answer
 
 
-def test_given_relation_and_wrong_size_when_add_rtuple_then_exception():
+def test_given_relation_and_wrong_size_when_add_tuple_then_exception():
     # given
-    relation = Relation("f", ("a", "b", "c"), SortedSet())
+    relation = Relation("f", ("a", "b", "c"), set())
 
     # when
     with pytest.raises(IncompatibleOperandError) as exception:
-        relation.add_rtuple(("1", "2"))
+        relation.add_tuple(("1", "2"))
 
     # then
     assert (
-        "Error: ('1', '2') is not compatible with header ('a', 'b', 'c') in Relation.add_rtuple"
+        "Error: ('1', '2') is not compatible with header ('a', 'b', 'c') in Relation.add_tuple"
         == str(exception.value)
     )
 
 
-def test_given_relation_when_add_rtuple_then_added():
+def test_given_relation_when_add_tuple_then_added():
     # given
-    relation = Relation("f", ("a", "b", "c"), SortedSet())
+    relation = Relation("f", ("a", "b", "c"), set())
 
     # when
-    relation.add_rtuple(("1", "2", "3"))
+    relation.add_tuple(("1", "2", "3"))
 
     # then
-    assert ("1", "2", "3") in relation.rtuples
+    assert ("1", "2", "3") in relation.set_of_tuples
 
 
 def test_given_mismatched_header_and_tuble_when_construct_then_exception():
     # given
     header = ("a", "b", "c")
-    rtuples = SortedSet([("1", "2")])
+    set_of_tuples = set([("1", "2")])
 
     # when
     with pytest.raises(IncompatibleOperandError) as exception:
-        _ = Relation("f", header, rtuples)
+        _ = Relation("f", header, set_of_tuples)
 
     # then
     assert (
-        "Error: ('1', '2') is not compatible with header ('a', 'b', 'c') in Relation.add_rtuple"
+        "Error: ('1', '2') is not compatible with header ('a', 'b', 'c') in Relation.add_tuple"
         == str(exception.value)
     )
 
 
 def test_given_mismatched_relations_when_difference_then_exception():
     # given
-    left = Relation("f", ("a", "b", "c"), SortedSet())
-    right = Relation("f", ("a", "b"), SortedSet())
+    left = Relation("f", ("a", "b", "c"), set())
+    right = Relation("f", ("a", "b"), set())
 
     # when
     with pytest.raises(IncompatibleOperandError) as exception:
@@ -116,9 +99,9 @@ def test_given_mismatched_relations_when_difference_then_exception():
 
 def test_given_matched_relations_when_difference_then_difference():
     # given
-    left = Relation("f", ("a", "b", "c"), SortedSet([("1", "2", "3"), ("2", "4", "6")]))
-    right = Relation("f", ("a", "b", "c"), SortedSet([("2", "4", "6")]))
-    expected = Relation("f", ("a", "b", "c"), SortedSet([("1", "2", "3")]))
+    left = Relation("f", ("a", "b", "c"), set([("1", "2", "3"), ("2", "4", "6")]))
+    right = Relation("f", ("a", "b", "c"), set([("2", "4", "6")]))
+    expected = Relation("f", ("a", "b", "c"), set([("1", "2", "3")]))
 
     # when
     answer = left.difference(right)

--- a/tests/test_relation.py
+++ b/tests/test_relation.py
@@ -5,9 +5,8 @@ from project3.relation import IncompatibleOperandError, Relation
 
 def test_given_empty_relation_when_add_tuple_then_tuple_in_relation():
     # given
-    name = "f"
     header = ("a", "b", "c")
-    relation = Relation(name, header, set())
+    relation = Relation(header, set())
     input = ("'1'", "'2'", "'3'")
 
     # when
@@ -20,10 +19,9 @@ def test_given_empty_relation_when_add_tuple_then_tuple_in_relation():
 
 def test_given_relation_when_str_then_match_expected():
     # given
-    name = "f"
     header = ("a", "b", "c")
     set_of_tuples = set([("'1'", "'2'", "'3'"), ("'1'", "'3'", "'5'")])
-    relation = Relation(name, header, set_of_tuples)
+    relation = Relation(header, set_of_tuples)
 
     expected = """+-----+-----+-----+
 |  a  |  b  |  c  |
@@ -41,7 +39,7 @@ def test_given_relation_when_str_then_match_expected():
 
 def test_given_relation_and_wrong_size_when_add_tuple_then_exception():
     # given
-    relation = Relation("f", ("a", "b", "c"), set())
+    relation = Relation(("a", "b", "c"), set())
 
     # when
     with pytest.raises(IncompatibleOperandError) as exception:
@@ -49,14 +47,14 @@ def test_given_relation_and_wrong_size_when_add_tuple_then_exception():
 
     # then
     assert (
-        "Error: ('1', '2') is not compatible with header ('a', 'b', 'c') in Relation.add_tuple"
+        "Error: ('1', '2') is not compatible with header ['a', 'b', 'c'] in Relation.add_tuple"
         == str(exception.value)
     )
 
 
 def test_given_relation_when_add_tuple_then_added():
     # given
-    relation = Relation("f", ("a", "b", "c"), set())
+    relation = Relation(("a", "b", "c"), set())
 
     # when
     relation.add_tuple(("1", "2", "3"))
@@ -65,26 +63,58 @@ def test_given_relation_when_add_tuple_then_added():
     assert ("1", "2", "3") in relation.set_of_tuples
 
 
-def test_given_mismatched_header_and_tuble_when_construct_then_exception():
+def test_given_mismatched_header_and_tuple_when_construct_then_exception():
     # given
     header = ("a", "b", "c")
     set_of_tuples = set([("1", "2")])
 
     # when
     with pytest.raises(IncompatibleOperandError) as exception:
-        _ = Relation("f", header, set_of_tuples)
+        _ = Relation(header, set_of_tuples)
 
     # then
     assert (
-        "Error: ('1', '2') is not compatible with header ('a', 'b', 'c') in Relation.add_tuple"
+        "Error: ('1', '2') is not compatible with header ['a', 'b', 'c'] in Relation.add_tuple"
+        == str(exception.value)
+    )
+
+
+def test_given_set_that_is_not_over_tuples_when_construct_then_exception():
+    # given
+    header = "a"
+    set_of_tuples = set(["1"])
+
+    # when
+    with pytest.raises(IncompatibleOperandError) as exception:
+        _ = Relation(header, set_of_tuples)
+
+    # then
+    assert (
+        "Error: 1 is not type compatible with Relation.RelationTuple in Relation.add_tuple"
+        == str(exception.value)
+    )
+
+
+def test_given_set_that_is_tuples_but_not_str_when_construct_then_exception():
+    # given
+    header = ("a", "b")
+    set_of_tuples = set([("1", 2)])
+
+    # when
+    with pytest.raises(IncompatibleOperandError) as exception:
+        _ = Relation(header, set_of_tuples)
+
+    # then
+    assert (
+        "Error: ('1', 2) is not type compatible with Relation.RelationTuple in Relation.add_tuple"
         == str(exception.value)
     )
 
 
 def test_given_mismatched_relations_when_difference_then_exception():
     # given
-    left = Relation("f", ("a", "b", "c"), set())
-    right = Relation("f", ("a", "b"), set())
+    left = Relation(("a", "b", "c"), set())
+    right = Relation(("a", "b"), set())
 
     # when
     with pytest.raises(IncompatibleOperandError) as exception:
@@ -92,16 +122,16 @@ def test_given_mismatched_relations_when_difference_then_exception():
 
     # then
     assert (
-        "Error: headers ('a', 'b', 'c') and ('a', 'b') are not compatible in Relation.difference"
+        "Error: headers ['a', 'b', 'c'] and ['a', 'b'] are not compatible in Relation.difference"
         == str(exception.value)
     )
 
 
 def test_given_matched_relations_when_difference_then_difference():
     # given
-    left = Relation("f", ("a", "b", "c"), set([("1", "2", "3"), ("2", "4", "6")]))
-    right = Relation("f", ("a", "b", "c"), set([("2", "4", "6")]))
-    expected = Relation("f", ("a", "b", "c"), set([("1", "2", "3")]))
+    left = Relation(("a", "b", "c"), set([("1", "2", "3"), ("2", "4", "6")]))
+    right = Relation(("a", "b", "c"), set([("2", "4", "6")]))
+    expected = Relation(("a", "b", "c"), set([("1", "2", "3")]))
 
     # when
     answer = left.difference(right)

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -7,28 +7,28 @@ from project3.reporter import query_report
 
 input_literals_no = (
     Predicate("SK", [Parameter.string("'c'"), Parameter.string("'c'")]),
-    Relation("SK", ("X", "Y"), set()),
+    Relation(("X", "Y"), set()),
 )
 expect_literals_no = "SK('c','c')? No"
 
 
 input_literals_yes = (
     Predicate("SK", [Parameter.string("'b'"), Parameter.string("'c'")]),
-    Relation("SK", ("X", "Y"), set([("'b'", "'c'")])),
+    Relation(("X", "Y"), set([("'b'", "'c'")])),
 )
 expect_literals_yes = "SK('b','c')? Yes(1)"
 
 
 input_mixed_no = (
     Predicate("SK", [Parameter.id("A"), Parameter.string("'c'")]),
-    Relation("SK", ("A",), set()),
+    Relation(("A",), set()),
 )
 expect_mixed_no = "SK(A,'c')? No"
 
 
 input_mixed_yes = (
     Predicate("SK", [Parameter.id("A"), Parameter.string("'c'")]),
-    Relation("SK", ("A",), set([("'a'",), ("'b'",)])),
+    Relation(("A",), set([("'a'",), ("'b'",)])),
 )
 expect_mixed_yes = """SK(A,'c')? Yes(2)
   A='a'
@@ -36,7 +36,7 @@ expect_mixed_yes = """SK(A,'c')? Yes(2)
 
 input_id_yes = (
     Predicate("SK", [Parameter.id("A"), Parameter.string("B")]),
-    Relation("SK", ("A", "B"), set([("'a'", "'b'"), ("'a'", "'c'"), ("'b'", "'c'")])),
+    Relation(("A", "B"), set([("'a'", "'b'"), ("'a'", "'c'"), ("'b'", "'c'")])),
 )
 expect_id_yes = """SK(A,B)? Yes(3)
   A='a', B='b'

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -1,45 +1,42 @@
 # type: ignore
 import pytest
-from sortedcontainers import SortedSet
 
 from project3.datalogprogram import Parameter, Predicate
 from project3.relation import Relation
-from project3.reporter import QueryReporter
+from project3.reporter import query_report
 
-input_literals_no = QueryReporter(
+input_literals_no = (
     Predicate("SK", [Parameter.string("'c'"), Parameter.string("'c'")]),
-    Relation("SK", ("X", "Y"), SortedSet()),
+    Relation("SK", ("X", "Y"), set()),
 )
 expect_literals_no = "SK('c','c')? No"
 
 
-input_literals_yes = QueryReporter(
+input_literals_yes = (
     Predicate("SK", [Parameter.string("'b'"), Parameter.string("'c'")]),
-    Relation("SK", ("X", "Y"), SortedSet([("'b'", "'c'")])),
+    Relation("SK", ("X", "Y"), set([("'b'", "'c'")])),
 )
 expect_literals_yes = "SK('b','c')? Yes(1)"
 
 
-input_mixed_no = QueryReporter(
+input_mixed_no = (
     Predicate("SK", [Parameter.id("A"), Parameter.string("'c'")]),
-    Relation("SK", ("A",), SortedSet()),
+    Relation("SK", ("A",), set()),
 )
 expect_mixed_no = "SK(A,'c')? No"
 
 
-input_mixed_yes = QueryReporter(
+input_mixed_yes = (
     Predicate("SK", [Parameter.id("A"), Parameter.string("'c'")]),
-    Relation("SK", ("A",), SortedSet([("'a'",), ("'b'",)])),
+    Relation("SK", ("A",), set([("'a'",), ("'b'",)])),
 )
 expect_mixed_yes = """SK(A,'c')? Yes(2)
   A='a'
   A='b'"""
 
-input_id_yes = QueryReporter(
+input_id_yes = (
     Predicate("SK", [Parameter.id("A"), Parameter.string("B")]),
-    Relation(
-        "SK", ("A", "B"), SortedSet([("'a'", "'b'"), ("'a'", "'c'"), ("'b'", "'c'")])
-    ),
+    Relation("SK", ("A", "B"), set([("'a'", "'b'"), ("'a'", "'c'"), ("'b'", "'c'")])),
 )
 expect_id_yes = """SK(A,B)? Yes(3)
   A='a', B='b'
@@ -67,9 +64,28 @@ expect_id_yes = """SK(A,B)? Yes(3)
 def test_given_query_reporter_when_str_then_match_expect(input, expect):
     # given
     # input, expect
+    query, answer = input
 
     # when
-    answer = str(input)
+    answer = query_report(query, answer)
+
+    # then
+    assert expect == answer
+
+
+def test_given_iterator_when_reporting_then_match_expect():
+    # given
+    answers = [
+        input_literals_no,
+        input_literals_yes,
+        input_mixed_no,
+        input_mixed_yes,
+        input_id_yes,
+    ]
+    expect = f"{expect_literals_no}\n{expect_literals_yes}\n{expect_mixed_no}\n{expect_mixed_yes}\n{expect_id_yes}"
+
+    # when
+    answer = "\n".join([query_report(i, j) for i, j in answers])
 
     # then
     assert expect == answer


### PR DESCRIPTION
Summary of changes:

- Change `SortedSet` to `set`
- Rename attributes and types in `Relation`
- Remove the `QueryReporter` and other reporting classes
- Change the interpreter interface to just return relations, rules, or predicates

Note from previous commit: the pass-off tests now use parameterization and custom marks to group tests by bucket. The change moves all the pass-off tests into a single file (`tests/test-passoff.py`). The `config_test.sh` script only needs to add the mark designation to the existing `pytest.ini` file that defines the custom marks for setup on each bucket.